### PR TITLE
Added xcpretty support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ env:
         - DESTINATION="arch=x86_64"
 
 before_install:
+    - brew update
+    - brew upgrade
+    - gem update
+    - gem install xcpretty
+    - gem install xcpretty-travis-formatter
     - xcodebuild -version
     - xcodebuild -showsdks
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ before_install:
     - xcodebuild -version
     - xcodebuild -showsdks
 
-script: xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug test
+script: xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug test | xcpretty

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ before_install:
     - gem update
     - gem install xcpretty
     - gem install xcpretty-travis-formatter
+    - gem clean
+    - pod update
     - xcodebuild -version
     - xcodebuild -showsdks
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ before_install:
     - xcodebuild -version
     - xcodebuild -showsdks
 
-script: xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug test | xcpretty
+script: xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug test | xcpretty -f `xcpretty-travis-formatter`

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ before_install:
     - xcodebuild -version
     - xcodebuild -showsdks
 
-script: xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug test | xcpretty -f `xcpretty-travis-formatter`
+script: xcodebuild -workspace "$WORKSPACE" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" -configuration Debug test | xcpretty -f `xcpretty-travis-formatter` && exit ${PIPESTATUS[0]}


### PR DESCRIPTION
- Added [`xcpretty`](https://github.com/supermarin/xcpretty) formatting to Travis CI builds
- Added [`xcpretty-travis-formatter`](https://github.com/kattrali/xcpretty-travis-formatter) xcpretty's un-official extension
- Added `brew update`, `brew upgrade`, `gem update`, `gem clean`, `pod update` in the `before_install:` section of the Travis CI